### PR TITLE
Force @assetType presence when generating a Key object

### DIFF
--- a/assets/key.go
+++ b/assets/key.go
@@ -72,6 +72,18 @@ func NewKey(m map[string]interface{}) (k Key, err errors.ICCError) {
 		k["@key"] = keyStr
 	}
 
+	// Validate if @assetType exists
+	_, typeExists := k["@assetType"].(string)
+	if !typeExists {
+		// Get asset type from @key
+		parts := strings.Split(k["@key"].(string), ":")
+		if len(parts) < 2 {
+			err = errors.NewCCError("cannot determine asset type from key", 400)
+			return
+		}
+		k["@assetType"] = parts[0]
+	}
+
 	for t := range k {
 		if t != "@key" && t != "@assetType" {
 			delete(k, t)

--- a/assets/key.go
+++ b/assets/key.go
@@ -59,6 +59,14 @@ func NewKey(m map[string]interface{}) (k Key, err errors.ICCError) {
 			if index != 0 {
 				keyExists = false
 			}
+		} else {
+			// Get asset type from @key
+			parts := strings.Split(k["@key"].(string), ":")
+			if len(parts) < 2 {
+				err = errors.NewCCError("cannot determine asset type from key", 400)
+				return
+			}
+			k["@assetType"] = parts[0]
 		}
 	}
 
@@ -70,18 +78,6 @@ func NewKey(m map[string]interface{}) (k Key, err errors.ICCError) {
 			err = errors.WrapError(err, "error generating key for asset")
 		}
 		k["@key"] = keyStr
-	}
-
-	// Validate if @assetType exists
-	_, typeExists := k["@assetType"].(string)
-	if !typeExists {
-		// Get asset type from @key
-		parts := strings.Split(k["@key"].(string), ":")
-		if len(parts) < 2 {
-			err = errors.NewCCError("cannot determine asset type from key", 400)
-			return
-		}
-		k["@assetType"] = parts[0]
 	}
 
 	for t := range k {

--- a/test/assets_key_test.go
+++ b/test/assets_key_test.go
@@ -39,3 +39,52 @@ func TestKeyJSON(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestKeyGenUsingAssetType(t *testing.T) {
+	m := map[string]interface{}{
+		"@assetType": "person",
+		"id":         "31820792048",
+	}
+
+	key, err := assets.NewKey(m)
+	if err != nil {
+		log.Println(err)
+		t.FailNow()
+	}
+
+	expectedKey := assets.Key{
+		"@assetType": "person",
+		"@key":       "person:47061146-c642-51a1-844a-bf0b17cb5e19",
+	}
+
+	if !reflect.DeepEqual(key, expectedKey) {
+		log.Println("these should be deeply equal")
+		log.Println(key)
+		log.Println(expectedKey)
+		t.FailNow()
+	}
+}
+
+func TestKeyGenUsingKey(t *testing.T) {
+	m := map[string]interface{}{
+		"@key": "person:47061146-c642-51a1-844a-bf0b17cb5e19",
+	}
+
+	key, err := assets.NewKey(m)
+	if err != nil {
+		log.Println(err)
+		t.FailNow()
+	}
+
+	expectedKey := assets.Key{
+		"@assetType": "person",
+		"@key":       "person:47061146-c642-51a1-844a-bf0b17cb5e19",
+	}
+
+	if !reflect.DeepEqual(key, expectedKey) {
+		log.Println("these should be deeply equal")
+		log.Println(key)
+		log.Println(expectedKey)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
This fix makes sure that any call to the NewKey function returns an object with the `@key` and `@assetType` properties. Currently, if only the key is sent in the map, the type is never present in the object, affecting the functionality of standard transactions, such as Update Asset.